### PR TITLE
completed DELETE method for /api/comments/:comment_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -441,3 +441,34 @@ describe("/api/articles/:article_id/comments", () => {
     })
   })
 })
+
+describe("/api/comments/:comment_id", () => {
+  describe("DELETE", () => {
+    test("204: Successfully deletes a comment and returns no content", () => {
+      return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+        .then(() => {
+          return db.query("SELECT * FROM comments WHERE comment_id = 1;");
+        }).then(({rows}) => {
+          expect(rows.length).toBe(0);
+        })
+    })
+    test("404: Responds with comment not found if comment_id does not exist", () => {
+      return request(app)
+        .delete("/api/comments/9999")
+        .expect(404)
+        .then(({body}) => {
+          expect(body.msg).toBe("comment not found");
+        })
+    })
+    test("400: Responds with bad request if comment_id is not a number", () => {
+      return request(app)
+        .delete("/api/comments/not-a-number")
+        .expect(400)
+        .then(({body}) => {
+          expect(body.msg).toBe("bad request");
+        })
+    })
+  })
+})

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const app = express();
 const {getEndpoints} = require("./controllers/api.controller");
 const {getAllTopics} = require("./controllers/topics.controller");
 const {getArticleById, getAllArticles, patchArticle} = require("./controllers/articles.controller");
-const {getCommentsByArticleId, postComment} = require("./controllers/comments.controller");
+const {getCommentsByArticleId, postComment, deleteComment} = require("./controllers/comments.controller");
 const {invalidPathHandler, serverErrorHandler, customErrorHandler, psqlErrorHandler} = require("./controllers/errors.controller");
 
 app.use(express.json());
@@ -22,6 +22,8 @@ app.get("/api/articles/:article_id", getArticleById);
 app.patch("/api/articles/:article_id", patchArticle);
 
 app.get("/api/articles", getAllArticles);
+
+app.delete("/api/comments/:comment_id", deleteComment);
 
 app.all('*', invalidPathHandler);
 

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,4 +1,4 @@
-const {fetchCommentsByArticleId, addComment} = require("../models/comments.model");
+const {fetchCommentsByArticleId, addComment, removeComment} = require("../models/comments.model");
 
 exports.getCommentsByArticleId = (req, res, next) => {
     const article_id = req.params.article_id;
@@ -19,5 +19,14 @@ exports.postComment = (req, res, next) => {
     }).catch((err) => {
         next(err);
     });
+}
 
+exports.deleteComment = (req, res, next) => {
+    const {comment_id} = req.params;
+
+    removeComment(comment_id).then(() => {
+        res.status(204).send();
+    }).catch((err) => {
+        next(err);
+    })
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -90,5 +90,12 @@
         "created_at": "2020-05-21 23:19:00.180Z"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes the specified comment",
+    "queries": [],
+    "exampleReqest": {
+      "comment_id": 1
+    }
   }
 }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -51,3 +51,17 @@ exports.addComment = (article_id, username, body) => {
         return rows[0];
     })
 }
+
+exports.removeComment = (id) => {
+    const queryString = `
+    DELETE FROM comments
+    WHERE comment_id = $1
+    RETURNING *;`;
+
+    return db.query(queryString, [id])
+    .then(({rows}) => {
+        if (rows.length === 0) {
+            return Promise.reject({status: 404, msg: "comment not found"});
+        }
+    })
+}


### PR DESCRIPTION
completed DELETE method for /api/comments/:comment_id endpoint with testing for:
- 204: Successfully deletes a comment and returns no content
- 404: Responds with comment not found if comment_id does not exist
- 400: Responds with bad request if comment_id is not a number

This commit also includes the updated endpoints.json with the new endpoint.