### PR TITLE
added comment_count to the output of GET /api/articles/:article_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -228,6 +228,32 @@ describe("/api/articles/:article_id", () => {
           expect(body.msg).toBe("article not found");
         })
     })
+    test("200: Responds with article object including comment_count", () => {
+      return request(app)
+        .get("/api/articles/1")
+        .expect(200)
+        .then(({body: {article}}) => {
+          const date = new Date(1594329060000).toISOString;
+          expect(article.article_id).toBe(1);
+          expect(article.title).toBe("Living in the shadow of a great man");
+          expect(article.topic).toBe("mitch");
+          expect(article.author).toBe("butter_bridge");
+          expect(article.body).toBe("I find this existence challenging");
+          expect(new Date(article.created_at).toISOString).toBe(date);
+          expect(article.votes).toBe(100);
+          expect(article.article_img_url).toBe("https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700");
+          expect(article).toHaveProperty("comment_count");
+          expect(article.comment_count).toBe(11);
+        })
+    })
+    test("200: Responds with comment_count of 0 if no comments exist for the specified article", () => {
+      return request(app)
+        .get("/api/articles/2")
+        .expect(200)
+        .then(({body: {article}}) => {
+          expect(article.comment_count).toBe(0);
+        })
+    })
   })
   describe("PATCH", () => {
     test("200: Responds with the updated article after increasing votes", () => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,7 +1,7 @@
 const {fetchArticleById, fetchAllArticles, updateArticle} = require("../models/articles.model");
 
 exports.getArticleById = (req, res, next) => {
-    const article_id = req.params.article_id;
+    const {article_id} = req.params;
     
     fetchArticleById(article_id).then((article) => {
         res.status(200).send({article});

--- a/endpoints.json
+++ b/endpoints.json
@@ -45,7 +45,8 @@
         "topic": "coding",
         "created_at": "2020-02-29 11:12:00.000Z",
         "votes": 0,
-        "article_img_url": "URL of image in the article.."
+        "article_img_url": "URL of image in the article..",
+        "comment_count": 0
       }
     }
   },

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,14 @@ const db = require("../db/connection");
 const {checkExists} = require("../db/seeds/utils");
 
 exports.fetchArticleById = (id) => {
-    return db.query(`SELECT * FROM articles WHERE article_id = $1`, [id])
+    const sqlString = `
+    SELECT articles.*, 
+    CAST(COUNT(comments.article_id) AS INTEGER) AS comment_count  
+    FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id;`;
+
+    return db.query(sqlString, [id])
         .then(({rows}) => {
             if (rows.length === 0) {
                 return Promise.reject({status: 404, msg: "article not found"});


### PR DESCRIPTION
Altered the SQL query in the GET /api/articles/:article_id endpoint to also return comment_count with testing for:
- 200: Responds with article object including comment_count
- 200: Responds with comment_count of 0 if no comments exist for the specified article

This commit also includes an update of endpoints.json to reflect the change in output.